### PR TITLE
rename to CarpentryConnect Davis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-We’re inviting Carpentries folks of all stripes — from new fans to veteran community-members, from all disciplines, near and far — to join us for CarpentryCon West! We’ve got housing and space for [DIBSI 2018](http://ivory.idyll.org/dibsi/), our annual bioinformatics summer institute, so we’ve set aside **Friday evening through Sunday morning, June 29-July 1**, for a Carpentries gathering in sunny Davis, California :sun_with_face:. 
+# CarpentryConnect Davis
 
-## What to expect
+We’re inviting Carpentries folks of all stripes — from new fans to veteran community-members, from all disciplines, near and far — to join us for CarpentryConnect Davis! We’ve got housing and space for [DIBSI 2018](http://ivory.idyll.org/dibsi/), our annual bioinformatics summer institute, so we’ve set aside **Friday evening through Sunday morning, June 29-July 1**, for a Carpentries gathering in sunny Davis, California :sun_with_face:. 
+
+### What to expect
 - Lots of social time with a small, friendly Carpentries community!
 - Keynote address from [Anelda van der Walt](https://twitter.com/aneldavdw) on  Carpentries communities in Africa
 - Other keynotes (TBD!) 
@@ -10,15 +12,15 @@ We’re inviting Carpentries folks of all stripes — from new fans to veteran c
 - Check-out opportunities for **new instructors**! (Attendance will fulfill the Discussion session requirement, and we will offer Demo opportunities for anyone who needs it!
 - **Un-conference** style activities proposed by attendees
 
-## Contibute your ideas!
+### Contibute your ideas!
 
 Want to organize a meet-up or activity? We’re happy to facilitate! Open an issue :point_up: :point_up:, or, contact us at dibsi.training@gmail.com. We can help to arrange space and connect you with collaborators to start the planning process.
 
-## How to sign up!
+### How to sign up!
 
 Registration is $50. Housing is available from 6/29-7/2 for $225, which includes breakfast and dinner (but not lunch).
 
-Please register by May 15th to guarantee your place at DIBSI West Coast Carpentry Con. If you’re coming from afar, you’ll need to register *soon* to obtain on-campus housing, which includes breakfast and dinner, as these spaces are limited.
+Please register by May 15th to guarantee your place at CarpentryConnect Davis. If you’re coming from afar, you’ll need to register *soon* to obtain on-campus housing, which includes breakfast and dinner, as these spaces are limited.
 
 **Local registration (no housing needed)** is here: 
 https://registration.genomecenter.ucdavis.edu/events/WCCC_DIBSI_2018/
@@ -26,14 +28,14 @@ https://registration.genomecenter.ucdavis.edu/events/WCCC_DIBSI_2018/
 **Out-of-town registration (includes housing)** is here;
 https://registration.genomecenter.ucdavis.edu/events/WCCC_with_Housing_DIBSI_2018/
 
-## Related events
+### Related events
 
 It’s also worth noting that we still have room at our Carpentries Instructor Training (with Anelda and Sher!) on June 25-26, and will be running a variety of Carpentries workshops on June 27-28. See [http://ivory.idyll.org/dibsi](http://ivory.idyll.org/dibsi) for more details!
 
-## Additional needs
+### Additional needs
 
 If you have any additional needs of any kind, please do not hesitate to ask! We will be adding information about local activities for children, nursing rooms, and ways we support people of all abilities. We welcome inquiries! 
 
-## Code of Conduct
+### Code of Conduct
 
 All contributions are expected to follow the Carpentries' [code of conduct](https://software-carpentry.org/conduct/).


### PR DESCRIPTION
This is the repo I made for collecting unconference sessions. We already have 2!

In this PR, I've updated the README to reflect the new name. 

How do you feel about the _name_ of the repo @ctb @karenword ... leave it as is or change the name? I always hesitate to rename repositories.